### PR TITLE
chore: Clean up db_update workflow

### DIFF
--- a/.github/workflows/db_update.yaml
+++ b/.github/workflows/db_update.yaml
@@ -16,18 +16,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login
-        uses: docker/login-action@v1
-        with:
-          registry: quay.io
-          username:  crozzy+ci
-          password: ${{ secrets.QUAY_TOKEN }}
-
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
           file: db.Dockerfile
           push: false
-          tags: quay.io/crozzy/clair-sqlite-db:latest
+          tags: clair-sqlite-db:latest
           secrets: |
             "aws=${{ secrets.AWS_CREDS }}"


### PR DESCRIPTION
We don't actually push an image anywhere so no need to login to a registry.

Signed-off-by: crozzy <joseph.crosland@gmail.com>