### PR TITLE
chore: Just check Dockerfile has correct tag after tagging

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,16 +31,8 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
-      - name: Update Dockerfile
+      - name: Check Dockerfile
         shell: bash
         run: |
           sed -i 's/clair-action:v.*/clair-action:${{ github.ref_name }}/' Dockerfile
-      - name: Create PR to update version
-        uses: peter-evans/create-pull-request@v4.1.4
-        with:
-          title: "${{ github.ref_name }} Dockerfile update"
-          body: "This is an automated changelog commit."
-          commit-message: "chore: ${{ github.ref_name }} Dockerfile update"
-          branch: "update-${{ github.ref_name }}"
-          signoff: true
-          delete-branch: true
+          git diff --exit-code


### PR DESCRIPTION
I realized that there is chicken and egg situation when the tag is created. The workflow runs to update the Dockerfile but when the auto-PR is merged it (obvious) didn't make it into the tag. For now updating the tag in the Dockerfile needs to be done prior to tagging, the CI will tell you if you haven't. At this point you'll need to re-tag and correct the error.

Signed-off-by: crozzy <joseph.crosland@gmail.com>