### PR TITLE
entrypoint: Remove reference to compiled DB

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,10 +33,6 @@ while getopts "r:p:f:o:c:d:u:w:b:" o; do
   esac
 done
 
-if [[ -z "$dbURL" ]]; then
-   dbURL="https://clair-sqlite-db.s3.amazonaws.com/matcher.zst"
-fi
-
 if [[ ${mode} = "update" ]]
 then
   clair-action update --db-path=${dbPath}


### PR DESCRIPTION
As we're leaning towards not hosting a pre-compiled vulnerability DB, remove the code that makes the default dbURL the s3 pre-compiled DB file.

Signed-off-by: crozzy <joseph.crosland@gmail.com>