### PR TITLE
Versioning: Add the ability to inject the version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,8 @@ jobs:
           file: cli.Dockerfile
           push: true
           tags: quay.io/projectquay/clair-action:${{ github.ref_name }}
+          build-args: |
+            CLAIR_ACTION_VERSION: ${{ github.ref_name }}
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -2,9 +2,14 @@ ARG GO_VERSION=1.18
 
 # Build the app
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build
+ARG CLAIR_ACTION_VERSION=""
 WORKDIR /build/
 ADD . /build/
-RUN go build -o clair-action ./cmd/cli
+RUN go build \
+    -o clair-action \
+    -trimpath \
+    -ldflags="-s -w$(test -n "${CLAIR_ACTION_VERSION}" && printf " -X 'main.Version=%s'" "${CLAIR_ACTION_VERSION}")" \
+    ./cmd/cli
 
 # Final image
 FROM registry.access.redhat.com/ubi8/ubi-minimal as final

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	app := &cli.App{
 		Name:                 "clair-action",
-		Version:              "0.0.1",
+		Version:              Version,
 		Usage:                "clair-action --help",
 		Description:          "A CLI application for running Clair v4 locally",
 		EnableBashCompletion: true,

--- a/cmd/cli/version.go
+++ b/cmd/cli/version.go
@@ -1,0 +1,68 @@
+// This is ported (with small changes) from Clair
+// https://github.com/quay/clair/blob/main/cmd/build.go
+// Having the Claircore version viewable in the CLI is important
+// all of the time, hence the minor change.
+package main
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"runtime/debug"
+	"time"
+)
+
+// Injected via git-export(1). See that man page and gitattributes(5).
+const (
+	// Needs a length check because GitHub zipballs/tarballs don't do the
+	// describe and just strip the pattern.
+	describe = `$Format:%(describe:match=v*)$`
+	revision = `$Format:%h (%cI)$`
+)
+
+func init() {
+	switch {
+	case Version != "":
+		// Had our version injected at build: do nothing.
+	case len(describe) > 0 && describe[0] != '$':
+		Version = describe
+	case revision[0] == '$':
+		// This is a helper for development. In production, we shouldn't assume
+		// that the process is running in a git repository or that git is
+		// installed. This is quite possibly wrong if run from the wrong working
+		// directory.
+		Version = `(random source build)`
+		ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+		defer done()
+		if _, err := exec.LookPath("git"); err != nil {
+			// Couldn't find a git binary: do nothing.
+			break
+		}
+		if err := exec.CommandContext(ctx, "git", "rev-parse", "--show-toplevel").Run(); err != nil {
+			// Couldn't find a git repository: do nothing.
+			break
+		}
+		out, err := exec.CommandContext(ctx, "git", "describe").Output()
+		if err != nil {
+			// Couldn't describe the current commit: do nothing.
+			break
+		}
+		Version = string(bytes.TrimSpace(out))
+	default:
+		Version = revision
+	}
+
+	// If we can read out the current binary's debug info, append the claircore
+	// version if there was a replacement.
+	if info, ok := debug.ReadBuildInfo(); ok {
+		for _, m := range info.Deps {
+			if m.Path != "github.com/quay/claircore" {
+				continue
+			}
+			Version += " (claircore " + m.Version + ")"
+		}
+	}
+}
+
+// Version is a version string, injected at release time for release builds.
+var Version string


### PR DESCRIPTION
Previously, the CLI version, the docker image tag and the git tag had some loose relationship. This change attempts to make releases more hands off and the CLI more informative by adding the revision and the claircore version.

Signed-off-by: crozzy <joseph.crosland@gmail.com>