### PR TITLE
chore: update project to use go1.20

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: quay.io/projectquay/golang:1.18
+    container: quay.io/projectquay/golang:1.20
     steps:
       - uses: actions/checkout@v3
       - run: go test ./...

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.20
 
 # Build the app
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair-action
 
-go 1.17
+go 1.20
 
 require (
 	github.com/doug-martin/goqu/v8 v8.6.0


### PR DESCRIPTION
This is needed as claircore now requires it.