### PR TITLE
update: avoid timeouts by increasing the default timeout

### DIFF
--- a/cmd/cli/update.go
+++ b/cmd/cli/update.go
@@ -36,7 +36,7 @@ func update(c *cli.Context) error {
 	}
 
 	cl := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: 30 * time.Second,
 	}
 
 	matcherOpts := &libvuln.Options{


### PR DESCRIPTION
Had a couple of transient errors reaching out to some debian and photon source with the 10s timeout, increasing to 30s.