### PR TITLE
chore: update go version in CI tests to 1.21

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: quay.io/projectquay/golang:1.20
+    container: quay.io/projectquay/golang:1.21
     steps:
       - uses: actions/checkout@v4
       - run: go test ./...


### PR DESCRIPTION
This is needed as claircore now requires 1.21.8 and also you need >=1.21 to be able to specify a patch version in the go.mod file.