### PR TITLE
chore: update the cli Dockerfile to go1.21

### DIFF
--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.20
+ARG GO_VERSION=1.21
 
 # Build the app
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build


### PR DESCRIPTION
This causes build problems as go.mod is now using 1.21.8.