### PR TITLE
chore: update documentation to account for self generating vuln DB

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ inputs:
   db-file-url:
     description: 'URL of the Sqlite3 zstd-compressed vulnerability database'
     required: false
-    default: 'https://clair-sqlite-db.s3.amazonaws.com/matcher.zst'
+    default: ''
   docker-config-dir:
     description: 'Path to the docker config dir for the image registry where image-ref is stored'
     required: false

--- a/tekton/cron.yaml
+++ b/tekton/cron.yaml
@@ -3,18 +3,18 @@ kind: CronJob
 metadata:
   name: update-db
 spec:
-  schedule: "20 * * * *"
+  schedule: "35 * * * *"
   jobTemplate:
     spec:
       template:
         spec:
           containers:
           - name: get-data
-            image: quay.io/projectquay/clair-action:v0.0.2
+            image: quay.io/projectquay/clair-action:v0.0.8
             command:
             - /bin/sh
             - -c
-            - microdnf install wget zstd && wget -q https://clair-sqlite-db.s3.amazonaws.com/matcher.zst && zstd -o /tmp/matcher.db -d matcher.zst
+            - clair-action update --db-path=/tmp/matcher.db
             volumeMounts:
             - name: vuln-store
               mountPath: /tmp

--- a/tekton/pipeline.yaml
+++ b/tekton/pipeline.yaml
@@ -18,7 +18,7 @@ spec:
             description: shared vuln data
         steps:
           - name: run-report
-            image: quay.io/projectquay/clair-action:v0.0.2
+            image: quay.io/projectquay/clair-action:v0.0.8
             script: |
               #!/bin/sh
               clair-action report --image-ref=debian:bullseye --db-path=$(workspaces.source.path)/matcher.db --format=quay

--- a/tekton/pvc.yaml
+++ b/tekton/pvc.yaml
@@ -1,7 +1,6 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  namespace: default
   name: vuln-store
 spec:
   accessModes:


### PR DESCRIPTION
Previously we had hosted a security DB that was updated nightly but as previously stated, this is no longer tenable. In place of this we added some machinary to allow users to (hopefully) easily generate it. This change updates the README to reflect those changes.