### PR TITLE
chore: add fast-forward ability

### DIFF
--- a/.github/workflows/check-fast-forward.yaml
+++ b/.github/workflows/check-fast-forward.yaml
@@ -1,0 +1,22 @@
+---
+    name: Check Fast Forward
+    on:
+      pull_request:
+        types: [opened, reopened, synchronize]
+    jobs:
+      check-fast-forward:
+        runs-on: ubuntu-latest
+    
+        permissions:
+          contents: read
+          # We appear to need write permission for both pull-requests and
+          # issues in order to post a comment to a pull request.
+          pull-requests: write
+          issues: write
+    
+        steps:
+          - name: Checking if fast forwarding is possible
+            uses: sequoia-pgp/fast-forward@v1
+            with:
+              merge: false
+              comment: on-error

--- a/.github/workflows/fast-forward.yaml
+++ b/.github/workflows/fast-forward.yaml
@@ -1,0 +1,23 @@
+---
+    name: Fast Forward
+    on:
+      issue_comment:
+        types: [created, edited]
+    jobs:
+      fast-forward:
+        # Only run if the comment contains the /fast-forward command.
+        if: ${{ contains(github.event.comment.body, '/fast-forward')
+                && github.event.issue.pull_request }}
+        runs-on: ubuntu-latest
+    
+        permissions:
+          contents: write
+          pull-requests: write
+          issues: write
+    
+        steps:
+          - name: Fast forwarding
+            uses: sequoia-pgp/fast-forward@v1
+            with:
+              merge: true
+              comment: on-error


### PR DESCRIPTION
This brings clair-action up to parity with the other clair projects by adding the ability to fast-forward PRs.