### PR TITLE
fix: add expressions matching the PostgreSQL query

### DIFF
--- a/datastore/query_builder.go
+++ b/datastore/query_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/doug-martin/goqu/v8"
+	"github.com/doug-martin/goqu/v8/exp"
 	_ "github.com/doug-martin/goqu/v9/dialect/sqlite3"
 	"github.com/quay/claircore"
 	"github.com/quay/claircore/datastore"
@@ -66,6 +67,10 @@ func buildGetQuery(record *claircore.IndexRecord, opts *datastore.GetOpts) (stri
 			ex = goqu.Ex{"dist_arch": record.Distribution.Arch}
 		case driver.RepositoryName:
 			ex = goqu.Ex{"repo_name": record.Repository.Name}
+		case driver.RepositoryKey:
+			ex = goqu.Ex{"repo_key": record.Repository.Key}
+		case driver.HasFixedInVersion:
+			ex = goqu.Ex{"fixed_in_version": goqu.Op{exp.NeqOp.String(): ""}}
 		default:
 			return "", fmt.Errorf("was provided unknown matcher: %v", m)
 		}


### PR DESCRIPTION
This adds the two query expressions to match the claircore PostgreSQL implementation.

See: https://github.com/quay/claircore/commit/3853221b90f1413654ee426d2b382c18022960ac
See: https://github.com/quay/claircore/commit/8dd6a350b2a0cf22d716781b2ef139b71a72366e