### PR TITLE
chore: bump Dockerfile to v0.0.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/clair-action:v0.0.8
+FROM quay.io/projectquay/clair-action:v0.0.9
 
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Preemptively bump the Dockerfile version to the tag about to be created.