### PR TITLE
chore: update go version to 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair-action
 
-go 1.21.8
+go 1.22.0
 
 require (
 	github.com/doug-martin/goqu/v8 v8.6.0


### PR DESCRIPTION
Claircore (and clair) need 1.22.0 so the action must abide.