### PR TITLE
chore: bump Dockerfile version to v0.0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/clair-action:v0.0.9
+FROM quay.io/projectquay/clair-action:v0.0.10
 
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 
 # Build the app
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build


### PR DESCRIPTION
Need to iterate the new version before the tag is create for reasons.