### PR TITLE
chore: bump Dockerfile to v0.0.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/clair-action:v0.0.10
+FROM quay.io/projectquay/clair-action:v0.0.11
 
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Preemptively bump the Dockerfile version to the tag about to be created.