### PR TITLE
chore: update minimum go version to 1.23

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,19 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
-    container: quay.io/projectquay/golang:1.21
+    strategy:
+      fail-fast: false
+      matrix:
+        go:
+          - 'stable'
+          - 'oldstable'
+    container: quay.io/projectquay/golang:1.23
     steps:
-      - uses: actions/checkout@v4
-      - run: go test ./...
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Test
+        run: go test ./...

--- a/cli.Dockerfile
+++ b/cli.Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.22
+ARG GO_VERSION=1.23
 
 # Build the app
 FROM quay.io/projectquay/golang:${GO_VERSION} AS build

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quay/clair-action
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/doug-martin/goqu/v8 v8.6.0


### PR DESCRIPTION
Dependencies will now require go1.23 and according to Go's support go1.22 is no longer supported (because of the release of 1.24).