### PR TITLE
Update Docker platforms in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           file: cli.Dockerfile
           push: true
-          platforms: linux/amd64,linux/ppc64le
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
           tags: quay.io/projectquay/clair-action:${{ github.ref_name }}
           build-args: |
             CLAIR_ACTION_VERSION=${{ github.ref_name }}


### PR DESCRIPTION
In order to enable this to be run on arm environments including on local machines or remote hardware (i.e. with tekton), we need to build this image for arm as well.