### PR TITLE
chore: bump Dockerfile version to v0.0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/projectquay/clair-action:v0.0.11
+FROM quay.io/projectquay/clair-action:v0.0.12
 
 COPY entrypoint.sh /
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Need to iterate the new version before the tag is create for reasons.