### PR TITLE
config: allow passing in a clair config file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
     description: 'Vulnerability database file created for mode `update` or DB file used for `report` mode'
     required: false
     default: ''
+  clair-config:
+    description: 'Path to a Clair v4 YAML config file (relative to GITHUB_WORKSPACE) for `update` mode'
+    required: false
+    default: ''
 
 runs:
   using: "docker"
@@ -52,3 +56,4 @@ runs:
     - '-u ${{ inputs.docker-config-dir }}'
     - '-w ${{ inputs.mode }}'
     - '-b ${{ inputs.db-file }}'
+    - '-g ${{ inputs.clair-config }}'

--- a/cmd/clair-action/update.go
+++ b/cmd/clair-action/update.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
+	clairconfig "github.com/quay/clair/config"
 	"github.com/quay/claircore/libvuln"
+	"github.com/quay/claircore/libvuln/driver"
 	_ "github.com/quay/claircore/updater/defaults"
 	"github.com/urfave/cli/v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/quay/clair-action/datastore"
 )
@@ -24,27 +29,46 @@ var updateCmd = &cli.Command{
 			Usage:   "where to look for the matcher DB",
 			EnvVars: []string{"DB_PATH"},
 		},
+		&cli.PathFlag{
+			Name:    "config",
+			Value:   "",
+			Usage:   "path to a Clair v4 YAML config file (full format only, drop-in format not supported); the `updaters` section controls updater sets and per-updater configuration",
+			EnvVars: []string{"CLAIR_CONFIG"},
+		},
 	},
 }
 
 func update(c *cli.Context) error {
 	ctx := c.Context
 	dbPath := c.String("db-path")
+	configPath := c.String("config")
+
 	matcherStore, err := datastore.NewSQLiteMatcherStore(dbPath, true)
 	if err != nil {
 		return fmt.Errorf("error creating sqlite backend: %v", err)
 	}
 
-	cl := &http.Client{
-		Timeout: 2 * time.Minute,
+	clientTimeout := 10 * time.Minute
+	var updaterSets []string
+	var updaterConfigs map[string]driver.ConfigUnmarshaler
+
+	if configPath != "" {
+		sets, cfgs, err := loadUpdaterOptions(configPath)
+		if err != nil {
+			return fmt.Errorf("error loading config: %v", err)
+		}
+		updaterSets = sets
+		updaterConfigs = cfgs
 	}
 
 	matcherOpts := &libvuln.Options{
-		Client:                   cl,
+		Client:                   &http.Client{Timeout: clientTimeout},
 		Store:                    matcherStore,
 		Locker:                   NewLocalLockSource(),
 		DisableBackgroundUpdates: true,
 		UpdateWorkers:            1,
+		UpdaterSets:              updaterSets,
+		UpdaterConfigs:           updaterConfigs,
 	}
 
 	lv, err := libvuln.New(ctx, matcherOpts)
@@ -56,4 +80,36 @@ func update(c *cli.Context) error {
 		return fmt.Errorf("error updating vulnerabilities: %v", err)
 	}
 	return nil
+}
+
+// loadUpdaterOptions parses a Clair v4 YAML config file and extracts the
+// updater-relevant fields. Only the `updaters` section is used; all other
+// Clair config fields (TLS, database connstrings, etc.) are parsed but
+// ignored. Note that the Clair v4 drop-in config format is not supported;
+// only the full config format (github.com/quay/clair/config.Config) is
+// accepted here.
+func loadUpdaterOptions(path string) (sets []string, configs map[string]driver.ConfigUnmarshaler, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("opening config file: %w", err)
+	}
+	defer f.Close()
+
+	var cfg clairconfig.Config
+	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
+		return nil, nil, fmt.Errorf("decoding config file: %w", err)
+	}
+
+	configs = make(map[string]driver.ConfigUnmarshaler, len(cfg.Updaters.Config))
+	for name, node := range cfg.Updaters.Config {
+		configs[name] = func(v any) error {
+			b, err := json.Marshal(node)
+			if err != nil {
+				return err
+			}
+			return json.Unmarshal(b, v)
+		}
+	}
+
+	return cfg.Updaters.Sets, configs, nil
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-while getopts "r:p:f:o:c:d:u:w:b:" o; do
+while getopts "r:p:f:o:c:d:u:w:b:g:" o; do
    case "${o}" in
        r)
          export imageRef="$(sed -e 's/^[ \t]*//'<<<"${OPTARG}")"
@@ -30,12 +30,15 @@ while getopts "r:p:f:o:c:d:u:w:b:" o; do
        b)
          export dbPath="$(sed -e 's/^[ \t]*//'<<<"${OPTARG}")"
        ;;
+       g)
+         export clairConfig="$(sed -e 's/^[ \t]*//'<<<"${OPTARG}")"
+       ;;
   esac
 done
 
 if [[ ${mode} = "update" ]]
 then
-  clair-action update --db-path=${dbPath}
+  clair-action update --db-path=${dbPath} ${clairConfig:+--config=${GITHUB_WORKSPACE}/${clairConfig}}
 else
   clair-action report \
       --image-path=${GITHUB_WORKSPACE}/${imagePath} \

--- a/go.mod
+++ b/go.mod
@@ -9,12 +9,14 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.8.0
 	github.com/klauspost/compress v1.18.3
+	github.com/quay/clair/config v1.4.3
 	github.com/quay/claircore v1.5.48
 	github.com/quay/zlog v1.1.9
 	github.com/remind101/migrate v0.0.0-20170729031349-52c1edff7319
 	github.com/rs/zerolog v1.34.0
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/tools v0.39.0
+	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.40.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9Z
 github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
 github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
+github.com/quay/clair/config v1.4.3 h1:ZrvqKJrAR2Noyl1XcMl9oOucdMJsdjGzqQqT/rzxb50=
+github.com/quay/clair/config v1.4.3/go.mod h1:MyYm2qGw55+I598zEpwpFFmBq1jp5NLIhBhCigv6tRM=
 github.com/quay/claircore v1.5.48 h1:JTJVlRmaxKWe9kUmHP3433JAADQvHIe5CQS544M3cUk=
 github.com/quay/claircore v1.5.48/go.mod h1:PYAACdI99elSBL31m/bRM3pdQSPoD0sbYccRcza/9Zs=
 github.com/quay/claircore/toolkit v1.0.0/go.mod h1:3ELtgf92x7o1JCTSKVOAqhcnCTXc4s5qiGaEDx62i20=


### PR DESCRIPTION
In order to pass configuration parameters to the updates we need to plumb them through the action flow, instead of doing this individually for all possible configuration parameters this change allows the user to pass a clair config file.